### PR TITLE
more additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,20 @@ sudo dnf swap mesa-va-drivers mesa-va-drivers-freeworld
 ## Set Hostname
 * `hostnamectl set-hostname YOUR_HOSTNAME`
 
+## Disable `NetworkManager-wait-online.service`
+* Disabling it can decrease the boot time of at least ~15s-20s:
+
+```
+sudo systemctl disable NetworkManager-wait-online.service
+```
+
+## Disable Gnome Software
+* Gnome software launches for some reason even tho it is not used, this takes at least 100MB of RAM upto 900MB (as reported anecdotically). You can remove from from the autostart in `/etc/xdg/autostart/org.gnome.Software.desktop`, by:
+
+```
+sudo rm /etc/xdg/autostart/org.gnome.Software.desktop
+```
+
 ## Custom DNS Servers
 * For people that want to setup custom DNS servers for better privacy
 ```

--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ Take the name, in this case, `luks-e88105e1-690f-423e-a168-a9f9a2e613e9`, and ex
 sudo cryptsetup --perf-no_read_workqueue --perf-no_write_workqueue --persistent refresh <name>
 ```
 
+## Set suspend to deep sleep
+
+**Only if your laptop drains fast under `s2idle`**
+
+In some laptop, the battery drains rapidly when suspended under `s2idle`, particularly those with Alder Lake CPUs. To fix this, you can set the kernel parameters with `mem_sleep_default=deep`. To do this properly, use the command, `grubby`:
+
+```
+sudo grubby --update-kernel=ALL --args="mem_sleep_default=deep"
+```
+
+Do a reboot, then check it with `cat /sys/power/mem_sleep`, where the `deep` should be enclosed with brackets (`[deep]`).
+
 ## Custom DNS Servers
 * For people that want to setup custom DNS servers for better privacy
 ```


### PR DESCRIPTION
* disabling gnome software from autostarting since it is not used can reduce the ram consumption in gnome fedora workstation
* networkmanager-wait-online.service just longers the boot time, hence disabling it can increase the boot time from 5s - 1min